### PR TITLE
Make the dependency on sfinv truly optional.

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,2 @@
 sfinv?
-default?
 awards?

--- a/gui.lua
+++ b/gui.lua
@@ -191,21 +191,22 @@ function crafting.result_select_on_receive_results(player, type, level, context,
 	end
 end
 
-
-sfinv.override_page("sfinv:crafting", {
-	get = function(self, player, context)
-		local formspec = crafting.make_result_selector(player, "inv", 1, { x = 8, y = 3 }, context)
-		formspec = formspec .. "list[detached:creative_trash;main;0,3.4;1,1;]" ..
-				"image[0.05,3.5;0.8,0.8;creative_trash_icon.png]"
-		return sfinv.make_formspec(player, context, formspec, true)
-	end,
-	on_player_receive_fields = function(self, player, context, fields)
-		if crafting.result_select_on_receive_results(player, "inv", 1, context, fields) then
-			sfinv.set_player_inventory_formspec(player)
+if minetest.global_exists("sfinv") then
+	sfinv.override_page("sfinv:crafting", {
+		get = function(self, player, context)
+			local formspec = crafting.make_result_selector(player, "inv", 1, { x = 8, y = 3 }, context)
+			formspec = formspec .. "list[detached:creative_trash;main;0,3.4;1,1;]" ..
+					"image[0.05,3.5;0.8,0.8;creative_trash_icon.png]"
+			return sfinv.make_formspec(player, context, formspec, true)
+		end,
+		on_player_receive_fields = function(self, player, context, fields)
+			if crafting.result_select_on_receive_results(player, "inv", 1, context, fields) then
+				sfinv.set_player_inventory_formspec(player)
+			end
+			return true
 		end
-		return true
-	end
-})
+	})
+end
 
 local node_fs_context = {}
 local node_serial = 0


### PR DESCRIPTION
gui.lua was called an sfinv function without checking if it were present.
Also remove the optional dependency on default (I think this can be done now that the recipes have been removed?)