### PR TITLE
Fix inventory resizing

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -216,10 +216,9 @@ function crafting.make_on_rightclick(type, level, inv_size)
 
 	local function show(player, context)
 		local formspec = crafting.make_result_selector(player, type, level, inv_size, context)
-		formspec = "size[" .. inv_size.x  .. "," .. (inv_size.y + 5.6) .. [[
-				list[current_player;main;0,4.7;8,1;]
-				list[current_player;main;0,5.85;8,3;8]
-			]] .. formspec
+		formspec = "size[" .. inv_size.x  .. "," .. (inv_size.y + 4.6) ..
+				"list[current_player;main;0," .. (inv_size.y + 1.7) ..";8,1;]" ..
+				"list[current_player;main;0," .. (inv_size.y + 1.85) ..";8,3;8]" .. formspec
 		minetest.show_formspec(player:get_player_name(), formname, formspec)
 	end
 


### PR DESCRIPTION
Properly resize the formspec when using different sizes inventory.
example:
`on_rightclick = crafting.make_on_rightclick('fire', 1, { x = 8, y = 2 }),`

i guessed the values and they seem to work in my subgame 