### PR TITLE
Fix crafting.make_on_rightclick()

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -217,9 +217,9 @@ function crafting.make_on_rightclick(type, level, inv_size)
 
 	local function show(player, context)
 		local formspec = crafting.make_result_selector(player, type, level, inv_size, context)
-		formspec = "size[" .. inv_size.x  .. "," .. (inv_size.y + 4.6) ..
-				"list[current_player;main;0," .. (inv_size.y + 1.7) ..";8,1;]" ..
-				"list[current_player;main;0," .. (inv_size.y + 1.85) ..";8,3;8]" .. formspec
+		formspec = "size[" .. inv_size.x  .. "," .. (inv_size.y + 5.6) ..
+				"]list[current_player;main;0," .. (inv_size.y + 1.7) ..";8,1;]" ..
+				"list[current_player;main;0," .. (inv_size.y + 2.85) ..";8,3;8]" .. formspec
 		minetest.show_formspec(player:get_player_name(), formname, formspec)
 	end
 


### PR DESCRIPTION
Someone forgot to put a **]** on the end of the size element and the first row of the player inventory overlapped the second row.