### PR TITLE
Bugfix: Drop craft and alert player if inventory is full

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -282,11 +282,11 @@ function crafting.perform_craft(name, inv, listname, outlistname, recipe)
 
 	-- Add output
 	if inv:room_for_item("main", recipe.output) then
-	   inv:add_item(outlistname, recipe.output)
+		inv:add_item(outlistname, recipe.output)
 	else
-	   local pos = minetest.get_player_by_name(name):get_pos()
-	   minetest.chat_send_player(name, "No room in inventory!")
-	   minetest.add_item(pos, recipe.output)
+		local pos = minetest.get_player_by_name(name):get_pos()
+		minetest.chat_send_player(name, "No room in inventory!")
+		minetest.add_item(pos, recipe.output)
 	end
 	return true
 end

--- a/api.lua
+++ b/api.lua
@@ -281,8 +281,13 @@ function crafting.perform_craft(name, inv, listname, outlistname, recipe)
 	end
 
 	-- Add output
-	inv:add_item(outlistname, recipe.output)
-
+	if inv:room_for_item("main", recipe.output) then
+	   inv:add_item(outlistname, recipe.output)
+	else
+	   local pos = minetest.get_player_by_name(name):get_pos()
+	   minetest.chat_send_player(name, "No room in inventory!")
+	   minetest.add_item(pos, recipe.output)
+	end
 	return true
 end
 


### PR DESCRIPTION
Fixes #28 

Does what it says on the tin; this simply warns the player his inventory is full and drops the crafted item at his feet.
