### PR TITLE
Fix crash in case of zero recipes

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -48,7 +48,12 @@ function crafting.make_result_selector(player, type, level, size, context)
 
 
 	local num_per_page = size.x * size.y
-	local max_pages = math.floor(0.999 + #recipes / num_per_page)
+
+	local max_pages = 1
+	if #recipes > 0 then
+		max_pages = math.floor((#recipes + num_per_page - 1) / num_per_page)
+	end
+
 	if page > max_pages or page < 1 then
 		page = ((page - 1) % max_pages) + 1
 		context.crafting_page = page


### PR DESCRIPTION
If a player has zero recipes (for example after a filter) `max_pages` will be 0, `page` == -nan, `start_i` == -nan https://github.com/rubenwardy/crafting/blob/b4ac60ba9b12db0867022ac8bf6b00338da9d56e/gui.lua#L51-L57 and depending on lua interpreter's mood it's going to crash here https://github.com/rubenwardy/crafting/blob/b4ac60ba9b12db0867022ac8bf6b00338da9d56e/gui.lua#L88-L89
Let's always have at least 1 page.