### PR TITLE
Silence a warning on MT 5.4.x

### DIFF
--- a/stations.lua
+++ b/stations.lua
@@ -18,8 +18,24 @@
 crafting.register_type("inv")
 crafting.register_type("furnace")
 
+local player_inv_hashes = {}
+
+local function check_for_changes()
+   for _, player in pairs(minetest.get_connected_players() or {}) do
+      if sfinv.get_or_create_context(player).page == "sfinv:crafting" then
+	 local hash = crafting.calc_inventory_list_hash(player:get_inventory(), "main")
+	 local old_hash = player_inv_hashes[player:get_player_name()]
+	 if hash ~= old_hash then
+	    sfinv.set_page(player, "sfinv:crafting")
+	 end
+      end
+   end
+
+   minetest.after(1, check_for_changes)
+end
+
+
 if minetest.global_exists("sfinv") then
-	local player_inv_hashes = {}
 
 	local trash = minetest.create_detached_inventory("crafting_trash", {
 		-- Allow the stack to be placed and remove it in on_put()
@@ -51,20 +67,7 @@ if minetest.global_exists("sfinv") then
 		end
 	})
 
-	local function check_for_changes()
-		for _, player in pairs(minetest.get_connected_players() or {}) do
-			if sfinv.get_or_create_context(player).page == "sfinv:crafting" then
-				local hash = crafting.calc_inventory_list_hash(player:get_inventory(), "main")
-				local old_hash = player_inv_hashes[player:get_player_name()]
-				if hash ~= old_hash then
-					sfinv.set_page(player, "sfinv:crafting")
-				end
-			end
-		end
-
-		minetest.after(1, check_for_changes)
-	end
-	check_for_changes()
+	minetest.after(1, check_for_changes)
 end
 
 minetest.register_node("crafting:work_bench", {


### PR DESCRIPTION
This silences a warning on Minetest 5.4.x+ about running minetest.get_connected_players at startup time.
