### PR TITLE
Move trashcan out of the way, to prevent accidental deletions

### DIFF
--- a/stations.lua
+++ b/stations.lua
@@ -39,8 +39,8 @@ if minetest.global_exists("sfinv") then
 					crafting.calc_inventory_list_hash(player:get_inventory(), "main")
 
 			local formspec = crafting.make_result_selector(player, "inv", 1, { x = 8, y = 3 }, context)
-			formspec = formspec .. "list[detached:crafting_trash;main;0,3.4;1,1;]" ..
-					"image[0.05,3.5;0.8,0.8;crafting_trash_icon.png]"
+			formspec = formspec .. "list[detached:crafting_trash;main;0,7.4;1,1;]" ..
+					"image[0.05,7.5;0.8,0.8;crafting_trash_icon.png]"
 			return sfinv.make_formspec(player, context, formspec, true)
 		end,
 		on_player_receive_fields = function(self, player, context, fields)


### PR DESCRIPTION
I've had reports of trouble with the trash can's location being so close to the inventory slots, some players have lost important stuff, on more than one occasion.
 This patch is what I did for Exile: move the trashcan away, down below the main inventory.