### PR TITLE
Sanitize string input on crafting guis

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -161,6 +161,15 @@ function crafting.make_result_selector(player, type, level, size, context)
 	return table.concat(formspec, "")
 end
 
+local function sanitize(badstring)
+   local disallowed = { "\\", "{", "}", "(", ")", "[", "]" }
+   badstring:trim():lower()
+   for i in ipairs(disallowed) do
+      badstring = badstring:gsub(disallowed[i],"")
+   end
+   return badstring
+end
+
 function crafting.result_select_on_receive_results(player, type, level, context, fields)
 	if fields.prev then
 		context.crafting_page = (context.crafting_page or 1) - 1
@@ -169,7 +178,7 @@ function crafting.result_select_on_receive_results(player, type, level, context,
 		context.crafting_page = (context.crafting_page or 1) + 1
 		return true
 	elseif fields.search or fields.key_enter_field == "query" then
-		context.crafting_query = fields.query:trim():lower()
+		context.crafting_query = sanitize(fields.query)
 		context.crafting_page  = 1
 		if context.crafting_query == "" then
 			context.crafting_query = nil

--- a/gui.lua
+++ b/gui.lua
@@ -162,7 +162,10 @@ function crafting.make_result_selector(player, type, level, size, context)
 end
 
 local function sanitize(badstring)
-   local disallowed = { "\\", "{", "}", "(", ")", "[", "]" }
+   local disallowed = { "\\", "{", "}",
+			--lua magic characters
+			"%(", "%)", "%[", "%]", "%.", "%$",
+			"%^", "%%", "%+", "%-", "%*", "%?"  }
    badstring:trim():lower()
    for i in ipairs(disallowed) do
       badstring = badstring:gsub(disallowed[i],"")

--- a/gui.lua
+++ b/gui.lua
@@ -162,7 +162,7 @@ function crafting.make_result_selector(player, type, level, size, context)
 end
 
 local function sanitize(badstring)
-   local disallowed = { "\\", "{", "}",
+   local disallowed = { "\\", "{", "}", "^", ";",
 			--lua magic characters
 			"%(", "%)", "%[", "%]", "%.", "%$",
 			"%^", "%%", "%+", "%-", "%*", "%?"  }


### PR DESCRIPTION
A player accidentally discovered that if you enter a backslash into the crafting gui's search field, it breaks, and you can't craft anything until the server was restarted. Pretty nasty when the backslash is next to your enter key.
 This patch simply ignores backslashes, as well as a few other characters I thought were sensible to exclude.